### PR TITLE
Improving Mock Method

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -15,35 +15,36 @@ global.window = dom.window;
 
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
-  configurable: true,
-  value: jest.fn().mockImplementation((query) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: jest.fn(), // deprecated
-    removeListener: jest.fn(), // deprecated
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
-  })),
+  value: (query) => {
+    return {
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {}, // deprecated
+      removeListener: () => {}, // deprecated
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => {},
+    };
+  },
 });
 
 const filterWord = require('../').default;
 
 describe('fitlers MS Word content', function () {
   it('transforms lists; cleans up styles', function () {
-      const result = filterWord(wordInput);
-      assert.equal(result, cleanedOutput);
+    const result = filterWord(wordInput);
+    assert.equal(result, cleanedOutput);
   });
 
   it('leaves non-Word content untouched', function () {
-      const content = `<p style="font-weight:bold">hello world</p>`;
-      const result = filterWord(content);
-      assert.equal(result, content);
+    const content = `<p style="font-weight:bold">hello world</p>`;
+    const result = filterWord(content);
+    assert.equal(result, content);
   });
 
   it('handles a complex case', function () {
-      const result = filterWord(complexInput);
-      assert.equal(result, complexCleanedOutput);
+    const result = filterWord(complexInput);
+    assert.equal(result, complexCleanedOutput);
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -32,18 +32,18 @@ const filterWord = require('../').default;
 
 describe('fitlers MS Word content', function () {
   it('transforms lists; cleans up styles', function () {
-    const result = filterWord(wordInput);
-    assert.equal(result, cleanedOutput);
+      const result = filterWord(wordInput);
+      assert.equal(result, cleanedOutput);
   });
 
   it('leaves non-Word content untouched', function () {
-    const content = `<p style="font-weight:bold">hello world</p>`;
-    const result = filterWord(content);
-    assert.equal(result, content);
+      const content = `<p style="font-weight:bold">hello world</p>`;
+      const result = filterWord(content);
+      assert.equal(result, content);
   });
 
   it('handles a complex case', function () {
-    const result = filterWord(complexInput);
-    assert.equal(result, complexCleanedOutput);
+      const result = filterWord(complexInput);
+      assert.equal(result, complexCleanedOutput);
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -14,11 +14,17 @@ global.URL = URL;
 global.window = dom.window;
 
 Object.defineProperty(window, 'matchMedia', {
-	value: () => ({
-		matches: false,
-		addListener: () => {},
-		removeListener: () => {}
-	})
+	writable: true,
+	value: jest.fn().mockImplementation((query) => ({
+	    matches: false,
+	    media: query,
+	    onchange: null,
+	    addListener: jest.fn(), // deprecated
+	    removeListener: jest.fn(), // deprecated
+	    addEventListener: jest.fn(),
+	    removeEventListener: jest.fn(),
+	    dispatchEvent: jest.fn(),
+	  }))
 })
 
 const filterWord = require('../').default;

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const {JSDOM} = require('jsdom');
+const { JSDOM } = require('jsdom');
 
 const wordInput = require('./fixtures/wordInput');
 const cleanedOutput = require('./fixtures/cleanedOutput');
@@ -7,42 +7,43 @@ const complexInput = require('./fixtures/complexInput');
 const complexCleanedOutput = require('./fixtures/complexCleanedOutput');
 
 const dom = new JSDOM();
-const {document, navigator, URL} = dom.window;
+const { document, navigator, URL } = dom.window;
 global.document = document;
 global.navigator = navigator;
 global.URL = URL;
 global.window = dom.window;
 
 Object.defineProperty(window, 'matchMedia', {
-	writable: true,
-	value: jest.fn().mockImplementation((query) => ({
-	    matches: false,
-	    media: query,
-	    onchange: null,
-	    addListener: jest.fn(), // deprecated
-	    removeListener: jest.fn(), // deprecated
-	    addEventListener: jest.fn(),
-	    removeEventListener: jest.fn(),
-	    dispatchEvent: jest.fn(),
-	  }))
-})
+  writable: true,
+  configurable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
 
 const filterWord = require('../').default;
 
 describe('fitlers MS Word content', function () {
-    it('transforms lists; cleans up styles', function () {
-        const result = filterWord(wordInput);
-        assert.equal(result, cleanedOutput);
-    });
+  it('transforms lists; cleans up styles', function () {
+    const result = filterWord(wordInput);
+    assert.equal(result, cleanedOutput);
+  });
 
-    it('leaves non-Word content untouched', function () {
-        const content = `<p style="font-weight:bold">hello world</p>`;
-        const result = filterWord(content);
-        assert.equal(result, content);
-    });
+  it('leaves non-Word content untouched', function () {
+    const content = `<p style="font-weight:bold">hello world</p>`;
+    const result = filterWord(content);
+    assert.equal(result, content);
+  });
 
-    it('handles a complex case', function () {
-        const result = filterWord(complexInput);
-        assert.equal(result, complexCleanedOutput);
-    });
+  it('handles a complex case', function () {
+    const result = filterWord(complexInput);
+    assert.equal(result, complexCleanedOutput);
+  });
 });


### PR DESCRIPTION
Updating the code to avoid conflicts when imported in other apps. `addListener` and `removeListener` are deprecated. This implementation is recommended by [Jest Docs](https://jestjs.io/docs/29.4/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom). 