### PR TITLE
fix: making matchMedia mock writeable and other improvements

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -14,12 +14,20 @@ global.URL = URL;
 global.window = dom.window;
 
 Object.defineProperty(window, 'matchMedia', {
-	value: () => ({
-		matches: false,
-		addListener: () => {},
-		removeListener: () => {}
-	})
-})
+    writable: true,
+    value: (query) => {
+      return {
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {}, // deprecated
+        removeListener: () => {}, // deprecated
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => {},
+      };
+    },
+  });
 
 const filterWord = require('../').default;
 


### PR DESCRIPTION
Making `matchMedia` mock writeable to make it mutable and avoid any issues when imported in another project. `addListener` and `removeListener` are deprecated. This implementation is recommended by [Jest Docs](https://jestjs.io/docs/29.4/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom). 